### PR TITLE
Prevent NEXUS_USERNAME property not found in initial import with gradle.

### DIFF
--- a/maven_push.gradle
+++ b/maven_push.gradle
@@ -10,6 +10,14 @@ if (isReleaseBuild()) {
     sonatypeRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
+def getRepositoryUsername() {
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
 afterEvaluate { project ->
     uploadArchives {
         repositories {
@@ -19,7 +27,7 @@ afterEvaluate { project ->
                 pom.artifactId = POM_ARTIFACT_ID
 
                 repository(url: sonatypeRepositoryUrl) {
-                    authentication(userName: NEXUS_USERNAME, password: NEXUS_PASSWORD)
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
                 }
 
                 pom.project {


### PR DESCRIPTION
It happens when you try to import with gradle and you haven't the NEXUS_USERNAME / PASSWORD setted in your gradle.properties.
