### PR TITLE
dont call setScrollBarStyle if scrollbarStyle is unset

### DIFF
--- a/SuperListviewLibrary/src/main/java/com/quentindommerc/superlistview/SuperListview.java
+++ b/SuperListviewLibrary/src/main/java/com/quentindommerc/superlistview/SuperListview.java
@@ -75,7 +75,8 @@ public class SuperListview extends BaseSuperAbsListview {
                 mList.setPadding(mPaddingLeft, mPaddingTop, mPaddingRight, mPaddingBottom);
             }
 
-            mList.setScrollBarStyle(mScrollbarStyle);
+            if (mScrollbarStyle != -1)
+                mList.setScrollBarStyle(mScrollbarStyle);
         }
     }
 


### PR DESCRIPTION
Calling setScrollbarstyle(-1) (atleast on a nexus4) sets a 20px extra padding on the right side if no scrollbarstyle (and padding) is set previously.
