### PR TITLE
Fix incompatible types for list divider resource.

### DIFF
--- a/SuperListviewLibrary/src/main/java/com/quentindommerc/superlistview/BaseSuperAbsListview.java
+++ b/SuperListviewLibrary/src/main/java/com/quentindommerc/superlistview/BaseSuperAbsListview.java
@@ -3,6 +3,7 @@ package com.quentindommerc.superlistview;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
+import android.graphics.drawable.Drawable;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -28,7 +29,7 @@ public abstract class BaseSuperAbsListview extends FrameLayout implements AbsLis
     protected ViewStub    mEmpty;
 
     protected float   mDividerHeight;
-    protected int     mDivider;
+    protected Drawable mDivider;
     protected boolean mClipToPadding;
     protected int     mPadding;
     protected int     mPaddingTop;
@@ -78,7 +79,7 @@ public abstract class BaseSuperAbsListview extends FrameLayout implements AbsLis
         TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.superlistview);
         try {
             mClipToPadding = a.getBoolean(R.styleable.superlistview_superlv__listClipToPadding, false);
-            mDivider = a.getColor(R.styleable.superlistview_superlv__listDivider, 0);
+            mDivider = a.getDrawable(R.styleable.superlistview_superlv__listDivider);
             mDividerHeight = a.getDimension(R.styleable.superlistview_superlv__listDividerHeight, 0.0f);
             mPadding = (int) a.getDimension(R.styleable.superlistview_superlv__listPadding, -1.0f);
             mPaddingTop = (int) a.getDimension(R.styleable.superlistview_superlv__listPaddingTop, 0.0f);


### PR DESCRIPTION
- Error in SuperListview.java:64: `incompatible types:
  int cannot be converted to Drawable getList().setDivider(mDivider);`
- This error was introduced through the merge in
  commit 9c93459df8769792a76b6da811b035c722d24a3d. Please review again!
- The original implementation to support drawable list dividers can
  be found in commit 366b88e01a7bd13b0325fb729742573063ae3268.
