### PR TITLE
Fix manifest merge bug

### DIFF
--- a/SuperListviewLibrary/src/main/AndroidManifest.xml
+++ b/SuperListviewLibrary/src/main/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.quentindommerc.superlistview.superlistview">
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher"
->
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
Library don't need application tag in manifest.
for apps that use @mipmap/ic_launcher instead of @drawable/ic_launcher it cause menifest merge error in compile time